### PR TITLE
Fix ReadLightNovel novel loading

### DIFF
--- a/index.json
+++ b/index.json
@@ -172,7 +172,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/ReadLightNovel.png",
       "id": 6118,
       "lang": "en",
-      "ver": "1.0.4",
+      "ver": "1.0.5",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/ReadLightNovel.lua
+++ b/src/en/ReadLightNovel.lua
@@ -86,7 +86,7 @@ return {
 			language = leftdetails:get(3):selectFirst("li"):text()
 		}
 		if details:selectFirst(".novel-detail-item.color-gray") ~= nil then
-			info.setAlternativeTitles(info, map(details:selectFirst(".novel-detail-item.color-gray"):select("li a"), text))
+			info:setAlternativeTitles(map(details:selectFirst(".novel-detail-item.color-gray"):select("li a"), text))
 		end
 
 		if loadChapters then

--- a/src/en/ReadLightNovel.lua
+++ b/src/en/ReadLightNovel.lua
@@ -1,4 +1,4 @@
--- {"id":6118,"ver":"1.0.4","libVer":"1.0.0","author":"TechnoJo4"}
+-- {"id":6118,"ver":"1.0.5","libVer":"1.0.0","author":"TechnoJo4"}
 
 local baseURL = "https://www.readlightnovel.org"
 local qs = Require("url").querystring
@@ -79,13 +79,15 @@ return {
 			title = doc:selectFirst(".block-title h1"):text(),
 			imageURL = left:selectFirst(".novel-cover img"):attr("src"),
 			description = table.concat(map(details:selectFirst(".novel-detail-body"):select("p"), text), "\n"),
-			alternativeTitles = map(details:selectFirst(".novel-detail-item.color-gray"):select("li a"), text),
 			status = ({
 				Ongoing = NovelStatus("PUBLISHING"),
 				Completed = NovelStatus("COMPLETED")
 			})[leftdetails:get(leftdetails:size()-1):selectFirst("li"):text()],
 			language = leftdetails:get(3):selectFirst("li"):text()
 		}
+		if details:selectFirst(".novel-detail-item.color-gray") ~= nil then
+			info.setAlternativeTitles(info, map(details:selectFirst(".novel-detail-item.color-gray"):select("li a"), text))
+		end
 
 		if loadChapters then
 			local i = 0


### PR DESCRIPTION
This fixes that novels without alternative titles get loaded again instead of getting a error message with the information of attempting to index nil.
An example of such a case would be be the novel _(Solo Leveling)_ with the link extension of _/solo-leveling-_  .