### PR TITLE
Fix ReadLightNovel Chapter Parsing

### DIFF
--- a/index.json
+++ b/index.json
@@ -172,7 +172,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/ReadLightNovel.png",
       "id": 6118,
       "lang": "en",
-      "ver": "1.0.5",
+      "ver": "1.0.6",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/ReadLightNovel.lua
+++ b/src/en/ReadLightNovel.lua
@@ -1,4 +1,4 @@
--- {"id":6118,"ver":"1.0.5","libVer":"1.0.0","author":"TechnoJo4"}
+-- {"id":6118,"ver":"1.0.6","libVer":"1.0.0","author":"TechnoJo4"}
 
 local baseURL = "https://www.readlightnovel.org"
 local qs = Require("url").querystring

--- a/src/en/ReadLightNovel.lua
+++ b/src/en/ReadLightNovel.lua
@@ -56,7 +56,7 @@ return {
 
 	getPassage = function(chapterURL)
 		local htmlElement = GETDocument(expandURL(chapterURL)):selectFirst("div#chapterhidden")
-		--htmlElement:select("br"):remove()
+		htmlElement:select("br"):remove()
 
 		-- Get the actual chapter content and remove the html. Due to the HTML format no need to add line breaks.
 		local content = htmlElement:html()
@@ -65,15 +65,7 @@ return {
 		content = content:gsub("</p>", "")
 		content = content:gsub("<br>", "")
 		content = content:gsub("<hr>", "-----")
-		--print(content)
-
-		htmlElement:select("br"):remove()
-		local contenttwo = htmlElement:html()
-		content = content:gsub("&nbsp;", " ") -- Do not break line here whitespace, not sure if it appears on this website
-		content = content:gsub("<p>", "")
-		content = content:gsub("</p>", "")
-		content = content:gsub("<hr>", "-----")
-		return content .. "\n\n\n" .. "BR removed before version:\n" .. contenttwo
+		return content
 	end,
 
 	parseNovel = function(novelURL, loadChapters)

--- a/src/en/ReadLightNovel.lua
+++ b/src/en/ReadLightNovel.lua
@@ -63,7 +63,7 @@ return {
 		content = content:gsub("&nbsp;", " ") -- Do not break line here whitespace, not sure if it appears on this website
 		content = content:gsub("<p>", "")
 		content = content:gsub("</p>", "")
-		content = content:gsub("<br>", "")
+		--content = content:gsub("<br>", "") -- Can be skipped as br gets removed.
 		content = content:gsub("<hr>", "-----")
 		return content
 	end,

--- a/src/en/ReadLightNovel.lua
+++ b/src/en/ReadLightNovel.lua
@@ -55,16 +55,25 @@ return {
 	},
 
 	getPassage = function(chapterURL)
-		return pipeline
-				(GETDocument(expandURL(chapterURL)):selectFirst(".container--content .row .desc"):children())
-				(filter, function(v)
-					return v:tagName() ~= "script"
-				end)
-				(map, text)
-				(filter, function(v)
-					return not v:match("support RLN")
-				end)
-				(table.concat, "\n")()
+		local htmlElement = GETDocument(expandURL(chapterURL)):selectFirst("div#chapterhidden")
+		--htmlElement:select("br"):remove()
+
+		-- Get the actual chapter content and remove the html. Due to the HTML format no need to add line breaks.
+		local content = htmlElement:html()
+		content = content:gsub("&nbsp;", " ") -- Do not break line here whitespace, not sure if it appears on this website
+		content = content:gsub("<p>", "")
+		content = content:gsub("</p>", "")
+		content = content:gsub("<br>", "")
+		content = content:gsub("<hr>", "-----")
+		--print(content)
+
+		htmlElement:select("br"):remove()
+		local contenttwo = htmlElement:html()
+		content = content:gsub("&nbsp;", " ") -- Do not break line here whitespace, not sure if it appears on this website
+		content = content:gsub("<p>", "")
+		content = content:gsub("</p>", "")
+		content = content:gsub("<hr>", "-----")
+		return content .. "\n\n\n" .. "BR removed before version:\n" .. contenttwo
 	end,
 
 	parseNovel = function(novelURL, loadChapters)


### PR DESCRIPTION
There is a hidden div that contains the whole chapter text again after the visible chapter text. Changed the getPassage to use that hidden chapter as it does not contain unnecessary bonus elements and transformed it into a string.

The only thing that I am not sure about is the single leading whitespace at the start of each text line. I have left those in to better show the new line starts. Could be removed by adding a whitespace at line 64 before the \<p\>.