### PR TITLE
Fix parsing of the novel title in NM Translations

### DIFF
--- a/index.json
+++ b/index.json
@@ -243,7 +243,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/NMTranslations.png",
       "id": 93082,
       "lang": "en",
-      "ver": "1.0.1",
+      "ver": "1.0.2",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/NMTranslations.lua
+++ b/src/en/NMTranslations.lua
@@ -1,4 +1,4 @@
--- {"id":93082,"ver":"1.0.1","libVer":"1.0.0","author":"Doomsdayrs","dep":[]}
+-- {"id":93082,"ver":"1.0.2","libVer":"1.0.0","author":"Doomsdayrs","dep":[]}
 local baseURL = "https://www.nanomashin.online"
 
 local function text(v)
@@ -30,7 +30,7 @@ return {
 		local document = GETDocument(baseURL .. url)
 
 		local info = NovelInfo {
-			title = document:selectFirst("h1.text-2xl"):text(),
+			title = document:selectFirst("h1.text-3xl"):text(),
 			imageURL = baseURL .. document:selectFirst("img.object-contain"):attr("src"),
 			description = document:selectFirst("div.pt-6.pb-8"):selectFirst("div.pt-6.pb-8"):text(),
 		}


### PR DESCRIPTION
NM Translations is broken again due to a minor change in their display of the title of their novels.