### PR TITLE
Update Madara to fix NovelTrench and LightNovelHeaven, and update BoxNovel

### DIFF
--- a/index.json
+++ b/index.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "Madara",
-      "ver": "2.0.1"
+      "ver": "2.1.0"
     }
   ],
   "scripts": [
@@ -43,7 +43,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/Foxaholic.png",
       "id": 173,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
       "md5": "c5977c9ba48c5115426fb3010cc65894"
     },
@@ -153,17 +153,17 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/NovelTrench.png",
       "id": 81,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
       "md5": ""
     },
     {
-      "name": "Woopread",
+      "name": "WoopRead",
       "fileName": "Woopread",
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/WoopRead.png",
       "id": 4217,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
       "md5": ""
     },
@@ -183,7 +183,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/LightNovelHeaven.png",
       "id": 2925,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
       "md5": "480c6c32b3cd81cde7faf19cc3496b0d"
     },

--- a/index.json
+++ b/index.json
@@ -123,7 +123,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/BoxNovel.png",
       "id": 2,
       "lang": "en",
-      "ver": "3.0.0",
+      "ver": "3.0.1",
       "libVer": "1.0.0",
       "md5": "c82a5cdff73aee7385e2da5cec371f89"
     },

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -162,24 +162,33 @@ function defaults:parseNovel(url, loadChapters)
 		title = doc:selectFirst(self.novelPageTitleSel):text(),
 		imageURL = img_src(doc:selectFirst("div.summary_image"):selectFirst("img.img-responsive"))
 	}
-	-- Determine status,
+	local status = nil
 	local statusElement = doc:selectFirst("div.post-status"):select("div.post-content_item")
 	local statusHeading = statusElement:get(0):select("div.summary-heading"):text()
 	local statusContent = statusElement:get(0):select("div.summary-content"):text()
-	if statusHeading == "Release" then
+	if statusHeading == "Project" then
+		status = ({
+			Active = NovelStatus("PUBLISHING"),
+			Dropped = NovelStatus("PAUSED"),
+			Finished = NovelStatus("COMPLETED"),
+			Teaser = NovelStatus("UNKNOWN"),
+			Hiatus = NovelStatus("PAUSED") -- Seemingly a secret on Foxaholic
+		})[statusContent]
+	elseif statusHeading == "Release" then
 		statusHeading = statusElement:get(1):select("div.summary-heading"):text()
 		statusContent = statusElement:get(1):select("div.summary-content"):text()
 	end
-	Log("Status", statusContent)
-	info:setStatus(({
-		OnGoing = NovelStatus("PUBLISHING"),
-		Completed = NovelStatus("COMPLETED"),
-		Active = NovelStatus("PUBLISHING"),
-		Dropped = NovelStatus("PAUSED"),
-		Finished = NovelStatus("COMPLETED"),
-		Teaser = NovelStatus("UNKNOWN"),
-		Hiatus = NovelStatus("PAUSED") -- Seemingly a secret on Foxaholic
-	})[statusContent])
+	if statusHeading == "Novel" or statusHeading == "Status" then
+		status = ({
+			OnGoing = NovelStatus("PUBLISHING"),
+			Completed = NovelStatus("COMPLETED")
+		})[statusContent]
+	end
+	if status == nil then
+		info:setStatus(NovelStatus("UNKNOWN"))
+	else
+		info:setStatus(status)
+	end
 
 	-- Not every Novel has an guaranteed author, artist or genres (looking at you NovelTrench).
 	if content:selectFirst("div.author-content") ~= nil then

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -166,14 +166,17 @@ function defaults:parseNovel(url, loadChapters)
 				and NovelStatus.PUBLISHING or NovelStatus.COMPLETED
 	}
 	-- Not every Novel has an guaranteed author, artist or genres (looking at you NovelTrench).
-	if content:selectFirst("div.author-content") ~= nil then
-		info:setAuthors( map(content:selectFirst("div.author-content"):select("a"), text) )
+	local selectedContent = content:selectFirst("div.author-content")
+	if selectedContent ~= nil then
+		info:setAuthors( map(selectedContent:select("a"), text) )
 	end
-	if content:selectFirst("div.artist-content") ~= nil then
-		info:setArtists( map(content:selectFirst("div.artist-content"):select("a"), text) )
+	selectedContent = content:selectFirst("div.artist-content")
+	if selectedContent ~= nil then
+		info:setArtists( map(selectedContent:select("a"), text) )
 	end
-	if content:selectFirst("div.genres-content") ~= nil then
-		info:setGenres( map(content:selectFirst("div.genres-content"):select("a"), text) )
+	selectedContent = content:selectFirst("div.genres-content")
+	if selectedContent ~= nil then
+		info:setGenres( map(selectedContent:select("a"), text) )
 	end
 
 	-- Chapters

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -158,7 +158,7 @@ function defaults:parseNovel(url, loadChapters)
 
 	local content = doc:selectFirst("div.post-content")
 	local info = NovelInfo {
-		description = doc:selectFirst("p"):text(),
+		description = table.concat(map(doc:selectFirst("div.summary__content"):select("p"), text), "\n"),
 		title = doc:selectFirst(self.novelPageTitleSel):text(),
 		imageURL = img_src(doc:selectFirst("div.summary_image"):selectFirst("img.img-responsive")),
 		status = doc:selectFirst("div.post-status"):select("div.post-content_item"):get(0)

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -182,10 +182,7 @@ function defaults:parseNovel(url, loadChapters)
 		status = ({
 			OnGoing = NovelStatus("PUBLISHING"),
 			Completed = NovelStatus("COMPLETED")
-		})[statusContent]
-	end
 	if status == nil then
-		info:setStatus(NovelStatus("UNKNOWN"))
 	else
 		info:setStatus(status)
 	end

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -120,23 +120,34 @@ function defaults:getPassage(url)
 	return pageOfElem(htmlElement, true)
 end
 
-local function img_src(e)
-	local srcset = e:attr("data-srcset")
+---@param image_element Element An img element of which the biggest image shall be selected.
+---@return string A link to the biggest image of the image_element.
+local function img_src(image_element)
+	-- Different extensions have the image(s) saved in different attributes. Not even uniformly for one extension.
+	-- Partially this comes down to script loading the pictures. Therefore, scour for a picture in the default HTML page.
 
+	-- Check data-srcset:
+	local srcset = image_element:attr("data-srcset")
 	if srcset ~= "" then
-		-- get largest image
-		local max, max_url = 0, ""
-
+		-- Get the largest image.
+		local max_size, max_url = 0, ""
 		for url, size in srcset:gmatch("(http.-) (%d+)w") do
-			if tonumber(size) > max then
-				max = tonumber(size)
+			if tonumber(size) > max_size then
+				max_size = tonumber(size)
 				max_url = url
 			end
 		end
-
 		return max_url
 	end
-	return e:attr("src")
+
+	-- Check data-src:
+	srcset = image_element:attr("data-src")
+	if srcset ~= "" then
+		return srcset
+	end
+
+	-- Default to src (the most likely place to be loaded via script):
+	return image_element:attr("src")
 end
 
 ---@param url string

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -160,11 +160,33 @@ function defaults:parseNovel(url, loadChapters)
 	local info = NovelInfo {
 		description = table.concat(map(doc:selectFirst("div.summary__content"):select("p"), text), "\n"),
 		title = doc:selectFirst(self.novelPageTitleSel):text(),
-		imageURL = img_src(doc:selectFirst("div.summary_image"):selectFirst("img.img-responsive")),
-		status = doc:selectFirst("div.post-status"):select("div.post-content_item"):get(0)
-		            :select("div.summary-content"):text() == "OnGoing"
-				and NovelStatus.PUBLISHING or NovelStatus.COMPLETED
+		imageURL = img_src(doc:selectFirst("div.summary_image"):selectFirst("img.img-responsive"))
 	}
+	local status = nil
+	local statusElement = doc:selectFirst("div.post-status"):select("div.post-content_item")
+	local statusHeading = statusElement:get(0):select("div.summary-heading"):text()
+	local statusContent = statusElement:get(0):select("div.summary-content"):text()
+	if statusHeading == "Project" then
+		status = ({
+			Active = NovelStatus("PUBLISHING"),
+			Dropped = NovelStatus("PAUSED"),
+			Finished = NovelStatus("COMPLETED"),
+			Teaser = NovelStatus("UNKNOWN"),
+			Hiatus = NovelStatus("PAUSED") -- Seemingly a secret on Foxaholic
+		})[statusContent]
+	elseif statusHeading == "Release" then
+		statusHeading = statusElement:get(1):select("div.summary-heading"):text()
+		statusContent = statusElement:get(1):select("div.summary-content"):text()
+	end
+	if statusHeading == "Novel" or statusHeading == "Status" then
+		status = ({
+			OnGoing = NovelStatus("PUBLISHING"),
+			Completed = NovelStatus("COMPLETED")
+	if status == nil then
+	else
+		info:setStatus(status)
+	end
+
 	-- Not every Novel has an guaranteed author, artist or genres (looking at you NovelTrench).
 	if content:selectFirst("div.author-content") ~= nil then
 		info:setAuthors( map(content:selectFirst("div.author-content"):select("a"), text) )

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -160,33 +160,11 @@ function defaults:parseNovel(url, loadChapters)
 	local info = NovelInfo {
 		description = table.concat(map(doc:selectFirst("div.summary__content"):select("p"), text), "\n"),
 		title = doc:selectFirst(self.novelPageTitleSel):text(),
-		imageURL = img_src(doc:selectFirst("div.summary_image"):selectFirst("img.img-responsive"))
+		imageURL = img_src(doc:selectFirst("div.summary_image"):selectFirst("img.img-responsive")),
+		status = doc:selectFirst("div.post-status"):select("div.post-content_item"):get(0)
+		            :select("div.summary-content"):text() == "OnGoing"
+				and NovelStatus.PUBLISHING or NovelStatus.COMPLETED
 	}
-	local status = nil
-	local statusElement = doc:selectFirst("div.post-status"):select("div.post-content_item")
-	local statusHeading = statusElement:get(0):select("div.summary-heading"):text()
-	local statusContent = statusElement:get(0):select("div.summary-content"):text()
-	if statusHeading == "Project" then
-		status = ({
-			Active = NovelStatus("PUBLISHING"),
-			Dropped = NovelStatus("PAUSED"),
-			Finished = NovelStatus("COMPLETED"),
-			Teaser = NovelStatus("UNKNOWN"),
-			Hiatus = NovelStatus("PAUSED") -- Seemingly a secret on Foxaholic
-		})[statusContent]
-	elseif statusHeading == "Release" then
-		statusHeading = statusElement:get(1):select("div.summary-heading"):text()
-		statusContent = statusElement:get(1):select("div.summary-content"):text()
-	end
-	if statusHeading == "Novel" or statusHeading == "Status" then
-		status = ({
-			OnGoing = NovelStatus("PUBLISHING"),
-			Completed = NovelStatus("COMPLETED")
-	if status == nil then
-	else
-		info:setStatus(status)
-	end
-
 	-- Not every Novel has an guaranteed author, artist or genres (looking at you NovelTrench).
 	if content:selectFirst("div.author-content") ~= nil then
 		info:setAuthors( map(content:selectFirst("div.author-content"):select("a"), text) )

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -182,7 +182,10 @@ function defaults:parseNovel(url, loadChapters)
 		status = ({
 			OnGoing = NovelStatus("PUBLISHING"),
 			Completed = NovelStatus("COMPLETED")
+		})[statusContent]
+	end
 	if status == nil then
+		info:setStatus(NovelStatus("UNKNOWN"))
 	else
 		info:setStatus(status)
 	end

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -110,10 +110,9 @@ function defaults:getPassage(url)
 	local htmlElement = GETDocument(self.expandURL(url)):selectFirst("div.text-left")
 
 	-- Remove/modify unwanted HTML elements to get a clean webpage.
-	htmlElement:removeAttr("style") -- Hopefully only temporary as a hotfix
 	htmlElement:select("div.lnbad-tag"):remove() -- LightNovelBastion text size
 
-	return pageOfElem(htmlElement)
+	return pageOfElem(htmlElement, true)
 end
 
 local function img_src(e)

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -162,33 +162,24 @@ function defaults:parseNovel(url, loadChapters)
 		title = doc:selectFirst(self.novelPageTitleSel):text(),
 		imageURL = img_src(doc:selectFirst("div.summary_image"):selectFirst("img.img-responsive"))
 	}
-	local status = nil
+	-- Determine status,
 	local statusElement = doc:selectFirst("div.post-status"):select("div.post-content_item")
 	local statusHeading = statusElement:get(0):select("div.summary-heading"):text()
 	local statusContent = statusElement:get(0):select("div.summary-content"):text()
-	if statusHeading == "Project" then
-		status = ({
-			Active = NovelStatus("PUBLISHING"),
-			Dropped = NovelStatus("PAUSED"),
-			Finished = NovelStatus("COMPLETED"),
-			Teaser = NovelStatus("UNKNOWN"),
-			Hiatus = NovelStatus("PAUSED") -- Seemingly a secret on Foxaholic
-		})[statusContent]
-	elseif statusHeading == "Release" then
+	if statusHeading == "Release" then
 		statusHeading = statusElement:get(1):select("div.summary-heading"):text()
 		statusContent = statusElement:get(1):select("div.summary-content"):text()
 	end
-	if statusHeading == "Novel" or statusHeading == "Status" then
-		status = ({
-			OnGoing = NovelStatus("PUBLISHING"),
-			Completed = NovelStatus("COMPLETED")
-		})[statusContent]
-	end
-	if status == nil then
-		info:setStatus(NovelStatus("UNKNOWN"))
-	else
-		info:setStatus(status)
-	end
+	Log("Status", statusContent)
+	info:setStatus(({
+		OnGoing = NovelStatus("PUBLISHING"),
+		Completed = NovelStatus("COMPLETED"),
+		Active = NovelStatus("PUBLISHING"),
+		Dropped = NovelStatus("PAUSED"),
+		Finished = NovelStatus("COMPLETED"),
+		Teaser = NovelStatus("UNKNOWN"),
+		Hiatus = NovelStatus("PAUSED") -- Seemingly a secret on Foxaholic
+	})[statusContent])
 
 	-- Not every Novel has an guaranteed author, artist or genres (looking at you NovelTrench).
 	if content:selectFirst("div.author-content") ~= nil then

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -124,7 +124,6 @@ local function img_src(e)
 		local max, max_url = 0, ""
 
 		for url, size in srcset:gmatch("(http.-) (%d+)w") do
-			print("URL: " .. url)
 			if tonumber(size) > max then
 				max = tonumber(size)
 				max_url = url

--- a/src/en/BoxNovel.lua
+++ b/src/en/BoxNovel.lua
@@ -1,4 +1,4 @@
--- {"id":2,"ver":"3.0.0","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
+-- {"id":2,"ver":"3.0.1","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
 
 return Require("Madara")("https://boxnovel.com", {
 	id = 2,
@@ -37,5 +37,5 @@ return Require("Madara")("https://boxnovel.com", {
 		"Xuanhuan",
 		"Yaoi"
 	},
-	latestNovelSel = "div.col-xs-12.col-md-6"
+	chaptersScriptLoaded = true
 })

--- a/src/en/Foxaholic.lua
+++ b/src/en/Foxaholic.lua
@@ -1,6 +1,6 @@
--- {"id":173,"ver":"2.0.0","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
+-- {"id":173,"ver":"2.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
 
-return Require("Madara")("https://foxaholic.com", {
+return Require("Madara")("https://www.foxaholic.com", {
 	id = 173,
 	name = "Foxaholic",
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/Foxaholic.png",
@@ -44,7 +44,7 @@ return Require("Madara")("https://foxaholic.com", {
 		japanese = "Japanese Novels",
 		original = "Original Novel",
 	},
-	doubleLoadChapters = true,
+	chaptersScriptLoaded = true,
 	latestNovelSel = "div.col-6",
 	novelPageTitleSel = "h1"
 })

--- a/src/en/LightNovelHeaven.lua
+++ b/src/en/LightNovelHeaven.lua
@@ -1,4 +1,4 @@
--- {"id":2925,"ver":"2.0.0","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
+-- {"id":2925,"ver":"2.0.1","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
 
 return Require("Madara")("https://lightnovelheaven.com", {
 	id = 2925,
@@ -7,5 +7,6 @@ return Require("Madara")("https://lightnovelheaven.com", {
 	genres = {},
 	novelListingURLPath = "novel-list",
 	shrinkURLNovel = "series",
-	doubleLoadChapters = true
+	chaptersScriptLoaded = true,
+	ajaxUsesFormData = false
 })

--- a/src/en/NovelTrench.lua
+++ b/src/en/NovelTrench.lua
@@ -1,4 +1,4 @@
--- {"id":81,"ver":"2.0.0","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
+-- {"id":81,"ver":"2.0.1","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
 
 return Require("Madara")("https://noveltrench.com",{
 	id = 81,
@@ -62,6 +62,10 @@ return Require("Madara")("https://noveltrench.com",{
 		"Xuanhuan",
 		"Yaoi"
 	},
+	-- Settings needed to enable the loading of chapters
+	chaptersScriptLoaded = true,
+	ajaxUsesFormData = false,
+
 	latestNovelSel = "div.col-12.col-md-4.badge-pos-1",
 	novelPageTitleSel = "h1",
 	novelListingURLPath = "manga"

--- a/src/en/Woopread.lua
+++ b/src/en/Woopread.lua
@@ -1,8 +1,8 @@
--- {"id":4217,"ver":"2.0.0","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
+-- {"id":4217,"ver":"2.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
 
 return Require("Madara")("https://woopread.com", {
     id = 4217,
-    name = "Woopread",
+    name = "WoopRead",
     imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/WoopRead.png",
     searchHasOper = true,
     shrinkURLNovel = "series",
@@ -44,5 +44,5 @@ return Require("Madara")("https://woopread.com", {
         ["complete"] = "Completed",
         ["slice-of-life"] = "Slice of Life",
     },
-    doubleLoadChapters = true
+    chaptersScriptLoaded = true
 })


### PR DESCRIPTION
- Removed forgotten debug print.
- Removed temporary style removal and enabled proper style removal via pageOfElem.
- Support missing author, artist and genres. (NovelTrench seems to be the only extension with that problem.)
- Support an additional ajax format request to load chapters (used by NovelTrench and LightNovelHeaven).
- Fixed image fetching for Foxaholic.
- Extended the description from the first `<p></p>` to the whole summary text.
- Update BoxNovel to be able to handle recent website changes.

I scrapped my publishing status change even though the status is mostly broken. Inconsistencies between different websites are to much of a hassle for me right now. Especially bad is Foxaholic, which has split the the publishing status in COO and translation. Though the inconsistency of not always being able to select the same HTML element is present in the other websites too.