### PR TITLE
ReadLightNovel Top-Level Domain Change

### DIFF
--- a/index.json
+++ b/index.json
@@ -173,7 +173,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/ReadLightNovel.png",
       "id": 6118,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/ReadLightNovel.lua
+++ b/src/en/ReadLightNovel.lua
@@ -1,10 +1,10 @@
--- {"id":6118,"ver":"2.0.0","libVer":"1.0.0","author":"TechnoJo4"}
+-- {"id":6118,"ver":"2.0.1","libVer":"1.0.0","author":"TechnoJo4"}
 
-local baseURL = "https://www.readlightnovel.org"
+local baseURL = "https://www.readlightnovel.me"
 local qs = Require("url").querystring
  
 local function shrinkURL(url)
-	return url:gsub(".-readlightnovel%.org", "")
+	return url:gsub(".-readlightnovel%.me", "")
 end
 
 local function expandURL(url)


### PR DESCRIPTION
ReadLightNovel had a top-level domain change, which killed _shrinkURL_ function. This just changes the top-level domain to the new one.