### PR TITLE
Update BoxNovel Ajax Usage

### DIFF
--- a/index.json
+++ b/index.json
@@ -123,7 +123,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/BoxNovel.png",
       "id": 2,
       "lang": "en",
-      "ver": "3.0.2",
+      "ver": "3.0.3",
       "libVer": "1.0.0",
       "md5": "c82a5cdff73aee7385e2da5cec371f89"
     },

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -195,7 +195,7 @@ function defaults:parseNovel(url, loadChapters)
 										:add("manga", id):build())
 				)
 			else
-				-- Used by NovelTrench and LightNovelHeaven.
+				-- Used by BoxNovel, NovelTrench and LightNovelHeaven.
 				doc = RequestDocument(
 						POST(self.baseURL .. "/" .. self.shrinkURLNovel .. "/" .. url .. self.ajaxSeriesUrl,
 								nil, nil)

--- a/src/en/BoxNovel.lua
+++ b/src/en/BoxNovel.lua
@@ -1,4 +1,4 @@
--- {"id":2,"ver":"3.0.2","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
+-- {"id":2,"ver":"3.0.3","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
 
 return Require("Madara")("https://boxnovel.com", {
 	id = 2,
@@ -38,5 +38,6 @@ return Require("Madara")("https://boxnovel.com", {
 		"Yaoi"
 	},
 	chaptersScriptLoaded = true,
+	ajaxUsesFormData = false,
 	novelPageTitleSel = "h1"
 })


### PR DESCRIPTION
BoxNovel has changed the way it loads the chapters. Before it used the normal _wp-admin/admin-ajax.php_ with form data but it has changed to _/series/<series name>/ajax/chapters_ without form data, due to the information already being in the ajax request URL.
Adjusted parameter to use ajax request without form data.

Has been tested, now loads the chapter list again.