### PR TITLE
Update VipNovel to new Madara Version

### DIFF
--- a/index.json
+++ b/index.json
@@ -73,7 +73,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/VipNovel.png",
       "id": 586,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
       "md5": "911fedf88cf4fad6ccc1561e625dd219"
     },

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -195,7 +195,7 @@ function defaults:parseNovel(url, loadChapters)
 										:add("manga", id):build())
 				)
 			else
-				-- Used by BoxNovel, NovelTrench and LightNovelHeaven.
+				-- Used by BoxNovel, NovelTrench, LightNovelHeaven and VipNovel.
 				doc = RequestDocument(
 						POST(self.baseURL .. "/" .. self.shrinkURLNovel .. "/" .. url .. self.ajaxSeriesUrl,
 								nil, nil)

--- a/src/en/VipNovel.lua
+++ b/src/en/VipNovel.lua
@@ -1,4 +1,4 @@
--- {"id":586,"ver":"2.0.0","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
+-- {"id":586,"ver":"2.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
 
 return Require("Madara")("https://vipnovel.com", {
 	id = 586,
@@ -43,5 +43,8 @@ return Require("Madara")("https://vipnovel.com", {
 		"Xuanhuan",
 		"Yaoi",
 		"Yuri"
-	}
+	},
+	chaptersScriptLoaded = true,
+	ajaxUsesFormData = false,
+	novelPageTitleSel = "h1"
 })


### PR DESCRIPTION
After BoxNovel, NovelTrench and LightNovelHeaven, VipNovel seems to also have updated to what I would not title as a new Madara version. 
Therefore, it uses a Ajax request without form data in the post request, where the used URL contains the novel information. See #174 for more or less the same changes and more information on the Ajax URL.

Seems the default HTML object of the title changed from _h3_ to _h1_ with the update. Due to not wanting to affect the other Madara extensions for now, I just updated that selection for VipNovel. 

Has been tested, chapters load again and the title after opening a novel is correct. I assume the same problem as with BoxNovel, NovelTrench and LightNovelHeaven will occur, i.e. that already bookmarked novels of VipNovel will get double chapters. This I did not test as I can not get chapters to load using the old method. I assume there will be the newly added chapters from the new Ajax usage and the old ones, which could have been read previously. Those old ones do not work. Due to what reason I am not sure as I do not have them. Maybe there was also an URL change of the chapters that results in them not getting overwritten. 

I might have come up with a better work around than doing a backup, moving the backup away, cleaning data and restoring the backup. This has not been tested though due to not having such novels in my library.

1. Update the app and the extensions.
2. Make a backup.
3. Remove all novels affected with double chapters from the library.
4. Purge the novel cache (Settings > Advanced - "Remove Novel Cache").
5. Restore backup.

The skips the moving of the backup with removing the affected novels and purging the novel cache to get rid of the old data. 