### PR TITLE
AsianHobbyist Fetch Search Encoding

### DIFF
--- a/index.json
+++ b/index.json
@@ -233,7 +233,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/AsianHobbyist.png",
       "id": 951,
       "lang": "en",
-      "ver": "2.0.2",
+      "ver": "2.0.3",
       "libVer": "1.0.0",
       "md5": "16348946cb5981a279d80b5f34ffe505"
     },

--- a/src/en/AsianHobbyist.lua
+++ b/src/en/AsianHobbyist.lua
@@ -1,6 +1,7 @@
--- {"id":951,"ver":"2.0.2","libVer":"1.0.0","author":"Doomsdayrs"}
+-- {"id":951,"ver":"2.0.3","libVer":"1.0.0","author":"Doomsdayrs"}
 
 local baseURL = "https://www.asianhobbyist.com"
+local encoding = ""
 
 ---@param v Element
 local function textOf(v)
@@ -40,12 +41,18 @@ end
 
 --- @param data table
 local function search(data)
+	-- Failsafe of getting the encoding in case the default listing never loaded the website
+	-- and therefore has not set the encoding.
+	if encoding == "" then
+		encoding = GETDocument(baseURL):selectFirst("meta[name=\"enc\"]"):attr("content")
+	end
+
 	local queryContent = data[QUERY]
 	local doc = RequestDocument(
 			POST(baseURL .. "/wp-admin/admin-ajax.php", nil,
 					FormBodyBuilder()
 							:add("action", "gsr")
-							:add("enc", "ecc07af28b")
+							:add("enc", encoding)
 							:add("src", queryContent):build())
 	)
 
@@ -90,6 +97,9 @@ return {
 	listings = {
 		Listing("Latest", false, function()
 			local document = GETDocument(baseURL)
+			-- The encoding is needed for search, gets loaded here due to the website being loaded already anyway.
+			-- Failsafe present in search in case encoding is empty.
+			encoding = document:selectFirst("meta[name=\"enc\"]"):attr("content")
 			return map(document:select("li.item"), function(v)
 				local a = v:selectFirst("a")
 				local image = a:selectFirst("img")

--- a/src/en/AsianHobbyist.lua
+++ b/src/en/AsianHobbyist.lua
@@ -69,11 +69,6 @@ local function search(data)
 		doc = getSearchResult(queryContent)
 	end
 
-	-- If the search result contains no novel, then it is just an empty HTML body.
-	if doc:text() == "" then
-		return {}
-	end
-
 	return map(doc:select("li.flex"), function(v)
 		local titleElement = v:selectFirst("div.title"):selectFirst("a")
 		return Novel {


### PR DESCRIPTION
The search encoding changes sometimes. This changes it to get the encoding from the website. 

The encoding gets fetched when the listing gets loaded as the website has been loaded at that point anyway. In case of someone either being fast enough to somehow skip loading the listing or doing a global search, I also added a fail safe in the search that loads the encoding in case it is not set already. 

The following scenario I have come up with that would break this implementation:
- The encoding gets set.
- The encoding changes on the website and web server.
- A search gets made (the listing does not get called cause due for example a global search, i.e. encoding does not get updated).
- Search sees the encoding is set, therefore uses set encoding that is outdated.

The problem I see with fetching the encoding every time in search is that, from what I can tell, the search function gets triggered every time a letter changes in search query. Therefore, the website will get potentially spammed with request to ensure the latest encoding. Assuming the website does not get cached.  Though then my example above would break search in that case too until the cache of the website gets dumped.

Whether this is a okay implementation or not therefore depends on the caching and how long a local variable gets kept.