### PR TITLE
Update Madara Extension Defaults, Change Foxaholic 

### DIFF
--- a/index.json
+++ b/index.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "Madara",
-      "ver": "2.1.0"
+      "ver": "2.2.0"
     }
   ],
   "scripts": [
@@ -46,7 +46,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/Foxaholic.png",
       "id": 173,
       "lang": "en",
-      "ver": "2.0.1",
+      "ver": "2.1.0",
       "libVer": "1.0.0",
       "md5": "c5977c9ba48c5115426fb3010cc65894"
     },
@@ -76,7 +76,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/VipNovel.png",
       "id": 586,
       "lang": "en",
-      "ver": "2.0.1",
+      "ver": "2.1.0",
       "libVer": "1.0.0",
       "md5": "911fedf88cf4fad6ccc1561e625dd219"
     },
@@ -126,7 +126,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/BoxNovel.png",
       "id": 2,
       "lang": "en",
-      "ver": "3.0.3",
+      "ver": "3.1.0",
       "libVer": "1.0.0",
       "md5": "c82a5cdff73aee7385e2da5cec371f89"
     },
@@ -156,7 +156,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/NovelTrench.png",
       "id": 81,
       "lang": "en",
-      "ver": "2.0.1",
+      "ver": "2.1.0",
       "libVer": "1.0.0",
       "md5": ""
     },
@@ -166,7 +166,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/WoopRead.png",
       "id": 4217,
       "lang": "en",
-      "ver": "2.0.2",
+      "ver": "2.1.0",
       "libVer": "1.0.0",
       "md5": ""
     },
@@ -186,7 +186,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/LightNovelHeaven.png",
       "id": 2925,
       "lang": "en",
-      "ver": "2.0.1",
+      "ver": "2.1.0",
       "libVer": "1.0.0",
       "md5": "480c6c32b3cd81cde7faf19cc3496b0d"
     },
@@ -196,7 +196,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/LightNovelBastion.png",
       "id": 762,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.1.0",
       "libVer": "1.0.0",
       "md5": "6e3dd280e11a4ba1b3dcf7f67b917e81"
     },

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -112,7 +112,11 @@ end
 ---@param url string
 ---@return string
 function defaults:getPassage(url)
-	local htmlElement = GETDocument(self.expandURL(url)):selectFirst("div.text-left")
+	local htmlElement = GETDocument(self.expandURL(url)):selectFirst("div.c-blog-post")
+	local title = htmlElement:selectFirst("ol.breadcrumb li.active"):text()
+	htmlElement = htmlElement:selectFirst("div.text-left")
+	-- Chapter title inserted before chapter text
+	htmlElement:child(0):before("<h1>" .. title .. "</h1>");
 
 	-- Remove/modify unwanted HTML elements to get a clean webpage.
 	htmlElement:select("div.lnbad-tag"):remove() -- LightNovelBastion text size

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -205,11 +205,10 @@ function defaults:parseNovel(url, loadChapters)
 
 		local chapterList = doc:select("li.wp-manga-chapter")
 		local novelList = AsList(map(chapterList, function(v)
-			local i = v:selectFirst("i")
 			return NovelChapter{
 				title = v:selectFirst("a"):text(),
 				link = self.shrinkURL(v:selectFirst("a"):attr("href")),
-				release = i and i:text() or v:selectFirst("img[alt]"):attr("alt")
+				release = v:selectFirst("span.chapter-release-date"):text()
 			}
 		end))
 		Reverse(novelList)

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -1,4 +1,4 @@
--- {"ver":"2.1.0","author":"TechnoJo4","dep":["url"]}
+-- {"ver":"2.2.0","author":"TechnoJo4","dep":["url"]}
 
 local encode = Require("url").encode
 local text = function(v)
@@ -11,7 +11,7 @@ local defaults = {
 	latestNovelSel = "div.col-12.col-md-6",
 	searchNovelSel = "div.c-tabs-item__content",
 	novelListingURLPath = "novel",
-	novelPageTitleSel = "h3",
+	novelPageTitleSel = "div.post-title",
 	shrinkURLNovel = "novel",
 	searchHasOper = false, -- is AND/OR operation selector present?
 	hasCloudFlare = false,
@@ -19,10 +19,10 @@ local defaults = {
 	chapterType = ChapterType.HTML,
 	-- If chaptersScriptLoaded is true, then a ajax request has to be made to get the chapter list.
 	-- Otherwise the chapter list is already loaded when loading the novel overview.
-	chaptersScriptLoaded = false,
+	chaptersScriptLoaded = true,
 	-- If ajaxUsesFormData is true, then a POST request will be send to baseURL/ajaxFormDataUrl.
 	-- Otherwise to baseURL/shrinkURLNovel/novelurl/ajaxSeriesUrl .
-	ajaxUsesFormData = true,
+	ajaxUsesFormData = false,
 	ajaxFormDataUrl = "/wp-admin/admin-ajax.php",
 	ajaxSeriesUrl = "ajax/chapters/"
 }
@@ -155,7 +155,7 @@ end
 ---@return NovelInfo
 function defaults:parseNovel(url, loadChapters)
 	local doc = GETDocument(self.expandURL(url))
-
+	print("Test title: " .. doc:selectFirst(self.novelPageTitleSel):text())
 	local content = doc:selectFirst("div.post-content")
 	local info = NovelInfo {
 		description = table.concat(map(doc:selectFirst("div.summary__content"):select("p"), text), "\n"),
@@ -184,7 +184,7 @@ function defaults:parseNovel(url, loadChapters)
 	if loadChapters then
 		if self.chaptersScriptLoaded then
 			if self.ajaxUsesFormData then
-				-- Used by Foxaholic.
+				-- Old method.
 				local button = doc:selectFirst("a.wp-manga-action-button")
 				local id = button:attr("data-post")
 
@@ -195,7 +195,7 @@ function defaults:parseNovel(url, loadChapters)
 										:add("manga", id):build())
 				)
 			else
-				-- Used by BoxNovel, NovelTrench, LightNovelHeaven, VipNovel and WoopRead.
+				-- Used by BoxNovel, Foxaholic, NovelTrench, LightNovelHeaven, VipNovel and WoopRead.
 				doc = RequestDocument(
 						POST(self.baseURL .. "/" .. self.shrinkURLNovel .. "/" .. url .. self.ajaxSeriesUrl,
 								nil, nil)

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -155,7 +155,7 @@ end
 ---@return NovelInfo
 function defaults:parseNovel(url, loadChapters)
 	local doc = GETDocument(self.expandURL(url))
-	print("Test title: " .. doc:selectFirst(self.novelPageTitleSel):text())
+
 	local content = doc:selectFirst("div.post-content")
 	local info = NovelInfo {
 		description = table.concat(map(doc:selectFirst("div.summary__content"):select("p"), text), "\n"),

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -155,11 +155,15 @@ end
 ---@return NovelInfo
 function defaults:parseNovel(url, loadChapters)
 	local doc = GETDocument(self.expandURL(url))
-
 	local content = doc:selectFirst("div.post-content")
+
+	-- Removing HOT or NEW from title.
+	local titleElement = doc:selectFirst(self.novelPageTitleSel)
+	titleElement:select("span"):remove()
+
 	local info = NovelInfo {
 		description = table.concat(map(doc:selectFirst("div.summary__content"):select("p"), text), "\n"),
-		title = doc:selectFirst(self.novelPageTitleSel):text(),
+		title = titleElement:text(),
 		imageURL = img_src(doc:selectFirst("div.summary_image"):selectFirst("img.img-responsive")),
 		status = doc:selectFirst("div.post-status"):select("div.post-content_item"):get(0)
 		            :select("div.summary-content"):text() == "OnGoing"

--- a/src/en/BoxNovel.lua
+++ b/src/en/BoxNovel.lua
@@ -1,9 +1,10 @@
--- {"id":2,"ver":"3.0.3","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
+-- {"id":2,"ver":"3.1.0","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://boxnovel.com", {
 	id = 2,
 	name = "BoxNovel",
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/BoxNovel.png",
+
 	genres = {
 		"Action",
 		"Adventure",
@@ -36,8 +37,5 @@ return Require("Madara")("https://boxnovel.com", {
 		"Xianxia",
 		"Xuanhuan",
 		"Yaoi"
-	},
-	chaptersScriptLoaded = true,
-	ajaxUsesFormData = false,
-	novelPageTitleSel = "h1"
+	}
 })

--- a/src/en/Foxaholic.lua
+++ b/src/en/Foxaholic.lua
@@ -1,4 +1,4 @@
--- {"id":173,"ver":"2.0.2","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.2.0"]}
+-- {"id":173,"ver":"2.1.0","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://www.foxaholic.com", {
 	id = 173,

--- a/src/en/Foxaholic.lua
+++ b/src/en/Foxaholic.lua
@@ -1,9 +1,13 @@
--- {"id":173,"ver":"2.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
+-- {"id":173,"ver":"2.0.2","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://www.foxaholic.com", {
 	id = 173,
 	name = "Foxaholic",
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/Foxaholic.png",
+
+	-- defaults values
+	latestNovelSel = "div.col-6",
+
 	genres = {
 		"Action",
 		"Adventure",
@@ -43,8 +47,5 @@ return Require("Madara")("https://www.foxaholic.com", {
 		chinese = "Chinese Novel",
 		japanese = "Japanese Novels",
 		original = "Original Novel",
-	},
-	chaptersScriptLoaded = true,
-	latestNovelSel = "div.col-6",
-	novelPageTitleSel = "h1"
+	}
 })

--- a/src/en/LightNovelBastion.lua
+++ b/src/en/LightNovelBastion.lua
@@ -1,10 +1,14 @@
--- {"id":762,"ver":"2.0.0","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
+-- {"id":762,"ver":"2.1.0","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://lightnovelbastion.com", {
 	id = 762,
 	name = "Light Novel Bastion",
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/LightNovelBastion.png",
+
+	-- defaults values
+	latestNovelSel = "div.col-6.col-md-3",
 	novelListingURLPath = "novels",
-	genres = {},
-	latestNovelSel = "div.col-6.col-md-3"
+	chaptersScriptLoaded = false,
+
+	genres = {}
 })

--- a/src/en/LightNovelHeaven.lua
+++ b/src/en/LightNovelHeaven.lua
@@ -1,12 +1,13 @@
--- {"id":2925,"ver":"2.0.1","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
+-- {"id":2925,"ver":"2.1.0","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://lightnovelheaven.com", {
 	id = 2925,
 	name = "Light Novel Heaven",
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/LightNovelHeaven.png",
-	genres = {},
+
+	-- defaults values
 	novelListingURLPath = "novel-list",
 	shrinkURLNovel = "series",
-	chaptersScriptLoaded = true,
-	ajaxUsesFormData = false
+
+	genres = {}
 })

--- a/src/en/NovelTrench.lua
+++ b/src/en/NovelTrench.lua
@@ -1,11 +1,16 @@
--- {"id":81,"ver":"2.0.1","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.0.0"]}
+-- {"id":81,"ver":"2.1.0","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://noveltrench.com",{
 	id = 81,
 	name = "NovelTrench",
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/NovelTrench.png",
+
+	-- defaults values
+	latestNovelSel = "div.col-12.col-md-4.badge-pos-1",
+	novelListingURLPath = "manga",
 	shrinkURLNovel = "manga",
 	searchHasOper = true,
+
 	genres = {
 		"Action",
 		"Adult",
@@ -61,12 +66,5 @@ return Require("Madara")("https://noveltrench.com",{
 		"Xianxia",
 		"Xuanhuan",
 		"Yaoi"
-	},
-	-- Settings needed to enable the loading of chapters
-	chaptersScriptLoaded = true,
-	ajaxUsesFormData = false,
-
-	latestNovelSel = "div.col-12.col-md-4.badge-pos-1",
-	novelPageTitleSel = "h1",
-	novelListingURLPath = "manga"
+	}
 })

--- a/src/en/VipNovel.lua
+++ b/src/en/VipNovel.lua
@@ -1,11 +1,14 @@
--- {"id":586,"ver":"2.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
+-- {"id":586,"ver":"2.1.0","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://vipnovel.com", {
 	id = 586,
 	name = "VipNovel",
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/VipNovel.png",
+
+	-- defaults values
 	novelListingURLPath = "vipnovel",
 	shrinkURLNovel = "vipnovel",
+
 	genres = {
 		"Action",
 		"Adult",
@@ -43,8 +46,5 @@ return Require("Madara")("https://vipnovel.com", {
 		"Xuanhuan",
 		"Yaoi",
 		"Yuri"
-	},
-	chaptersScriptLoaded = true,
-	ajaxUsesFormData = false,
-	novelPageTitleSel = "h1"
+	}
 })

--- a/src/en/Woopread.lua
+++ b/src/en/Woopread.lua
@@ -1,13 +1,15 @@
--- {"id":4217,"ver":"2.0.2","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.0.0"]}
+-- {"id":4217,"ver":"2.1.0","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://woopread.com", {
     id = 4217,
     name = "WoopRead",
     imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/WoopRead.png",
-    searchHasOper = true,
-    shrinkURLNovel = "series",
+
+    -- defaults values
     novelListingURLPath = "novellist",
-    novelPageTitleSel = "h1",
+    shrinkURLNovel = "series",
+    searchHasOper = true,
+
     genres = {
         "Action",
         "Adult",
@@ -43,8 +45,5 @@ return Require("Madara")("https://woopread.com", {
         ["on-going"] = "Ongoing",
         ["complete"] = "Completed",
         ["slice-of-life"] = "Slice of Life",
-    },
-    chaptersScriptLoaded = true,
-    ajaxUsesFormData = false,
-    novelPageTitleSel = "h1"
+    }
 })


### PR DESCRIPTION
- Madara: Update default values to the ones that all extensions used but Foxaholic
- Extensions that use Madara: Remove values that are the same as default
- Madara: Update title identifier
- Madara: Remove badges from title (like HOT or NEW)
- Madara: Update chapter release identifier
- Madara: Add a h1 with chapter title before chapter text

These changes are specifically target for the the follow purposes:
- Foxaholic: Changed default values fixes Ajax usage (see #178 ) 
- LightNovelBastion: Badges removed from title
- LightNovelHeaven: Title fixed
- Extensions: Some extensions have a proper title in chapter text, most do not. Add a proper title before every chapter. 

The added title is more of a preference on my side. I dislike opening a chapter and having to do extra button presses to check what the chapter title is. Disadvantage: The extensions already having one will have two, first the h1, that got added, followed by typically a h3, but not necessarily. It is sometimes inconsistent among chapters of the same novel.

Changes should not break #175 .

Everything but Noveltrench has been tested due to the side not being accessible for me. Asked someone to test Noveltrench for me. Awaiting feedback on that.