### PR TITLE
Fix support for authors/titles/genres/status on NovelFull

### DIFF
--- a/index.json
+++ b/index.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "NovelFull",
-      "ver": "2.0.1"
+      "ver": "2.0.2"
     },
     {
       "name": "url",
@@ -56,9 +56,9 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/NovelFull.png",
       "id": 1,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
-      "md5": "5f95559b552725914228f3b29126fd1"
+      "md5": "ad8a6211419b89c1c9bda5d6cd07e19e"
     },
     {
       "name": "FastNovel",

--- a/lib/NovelFull.lua
+++ b/lib/NovelFull.lua
@@ -1,4 +1,4 @@
--- {"ver":"2.0.1","author":"TechnoJo4","dep":["url"]}
+-- {"ver":"2.0.2","author":"TechnoJo4","dep":["url"]}
 
 -- rename this if you ever figure out its real name
 
@@ -80,9 +80,11 @@ function defaults:parseNovel(url, loadChapters)
 
 	local meta_offset = elem:size() < 3 and self.meta_offset or 0
 
-	info:setArtists(map(elem:get(meta_offset):select("a"), text))
-	info:setGenres(map(elem:get(meta_offset + 1):select("a"), text))
-	info:setStatus(NovelStatus(elem:get(meta_offset + 3):select("a"):text() == "Completed" and 1 or 0))
+	info:setAuthors(          (map(elem:get(meta_offset    ):select("a"), text)))
+	info:setAlternativeTitles((map(elem:get(meta_offset + 1):select("a"), text)))
+	info:setGenres(           (map(elem:get(meta_offset + 2):select("a"), text)))
+	--info:setSources(        (map(elem:get(meta_offset + 3):select("a"), text)))
+	info:setStatus(   (NovelStatus(elem:get(meta_offset + 4):select("a"):text() == "Completed" and 1 or 0)))
 
 	info:setImageURL((self.appendURLToInfoImage and self.baseURL or "") .. doc:selectFirst("div.book img"):attr("src"))
 	info:setDescription(table.concat(map(doc:select("div.desc-text p"), text), "\n"))

--- a/lib/NovelFull.lua
+++ b/lib/NovelFull.lua
@@ -80,11 +80,15 @@ function defaults:parseNovel(url, loadChapters)
 
 	local meta_offset = elem:size() < 3 and self.meta_offset or 0
 
-	info:setAuthors(          (map(elem:get(meta_offset    ):select("a"), text)))
-	info:setAlternativeTitles((map(elem:get(meta_offset + 1):select("a"), text)))
-	info:setGenres(           (map(elem:get(meta_offset + 2):select("a"), text)))
-	--info:setSources(        (map(elem:get(meta_offset + 3):select("a"), text)))
-	info:setStatus(   (NovelStatus(elem:get(meta_offset + 4):select("a"):text() == "Completed" and 1 or 0)))
+	function meta_links(i)
+		return map(elem:get(meta_offset + i):select("a"), text)
+	end
+
+	info:setAuthors(meta_links(0))
+	info:setAlternativeTitles(meta_links(1))
+	info:setGenres(meta_links(2))
+	info:setStatus(elem:get(meta_offset + 4):select("a"):text() == "Completed"
+			and NovelStatus.COMPLETED or NovelStatus.UNKNOWN)
 
 	info:setImageURL((self.appendURLToInfoImage and self.baseURL or "") .. doc:selectFirst("div.book img"):attr("src"))
 	info:setDescription(table.concat(map(doc:select("div.desc-text p"), text), "\n"))

--- a/src/en/NovelFull.lua
+++ b/src/en/NovelFull.lua
@@ -1,11 +1,10 @@
--- {"id":1,"ver":"2.0.0","libVer":"1.0.0","author":"TechnoJo4","dep":["NovelFull>=2.0.0"]}
+-- {"id":1,"ver":"2.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["NovelFull>=2.0.2"]}
 
 return Require("NovelFull")("http://novelfull.com", {
 	id = 1,
 	name = "NovelFull",
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/NovelFull.png",
-	genres = {},
-
+	
 	meta_offset = 0,
 	ajax_hot = "/ajax-search?type=hot",
 	ajax_latest = "/ajax-search?type=latest",


### PR DESCRIPTION
Before: author is blank, artist is filled with author, publishing state is completed, genre is blank 
After: author is filled, artist is blank, publishing state is filled, genre is filled, alternatetitles is filled and hidden
I did not modify ReadNovelFull nor MNovelFree, which depend on lib/novelfull and are hidden from the index, in this branch.