### PR TITLE
hide <p class="hid">Visit readlightnovel.me for extra chapters.</p>

### DIFF
--- a/index.json
+++ b/index.json
@@ -176,7 +176,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/ReadLightNovel.png",
       "id": 6118,
       "lang": "en",
-      "ver": "2.0.2",
+      "ver": "2.0.3",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/ReadLightNovel.lua
+++ b/src/en/ReadLightNovel.lua
@@ -1,4 +1,4 @@
--- {"id":6118,"ver":"2.0.2","libVer":"1.0.0","author":"TechnoJo4"}
+-- {"id":6118,"ver":"2.0.3","libVer":"1.0.0","author":"TechnoJo4"}
 
 local baseURL = "https://www.readlightnovel.me"
 local qs = Require("url").querystring
@@ -59,7 +59,8 @@ return {
 		local htmlElement = GETDocument(expandURL(chapterURL)):selectFirst("div#chapterhidden")
 
 		-- Remove/modify unwanted HTML elements to get a clean webpage.
-		htmlElement:removeAttr("class") -- Remove hidden
+		htmlElement:select(".hid"):remove() -- Hide .hid elements
+		htmlElement:removeAttr("class") -- Show .hidden elements
 		--htmlElement:select("br"):remove()
 
 		return pageOfElem(htmlElement)


### PR DESCRIPTION
On the website, .hid is removed with `.hid{display:none}`. This uses `htmlElement:select(".hid"):remove()`.
If it's not specific enough, it can be changed to `htmlElement:select("p.hid:ContainsOwn(Visit readlightnovel.me for extra chapters.)")`.
If this should be a setting, I can make it a setting. With NOVA, there are two elements that aren't normally removed, so I made a setting for them. With ReadLightNovel, this element is normally removed, so it doesn't seem to need a setting.

`java -jar ./extension-tester.jar src/en/ReadLightNovel.lua --target-novel "\/he-who-fights-with-monsters" --print-passages` https://www.readlightnovel.me/he-who-fights-with-monsters/chapter-1 The .hid element appears 3 times on this page