### PR TITLE
RoyalRoad chapter times

### DIFF
--- a/index.json
+++ b/index.json
@@ -246,7 +246,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/RoyalRoad.png",
       "id": 36833,
       "lang": "en",
-      "ver": "1.0.1",
+      "ver": "1.0.2",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/RoyalRoad.lua
+++ b/src/en/RoyalRoad.lua
@@ -1,4 +1,4 @@
--- {"id":36833,"ver":"1.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["url>=1.0.0","CommonCSS>=1.0.0"]}
+-- {"id":36833,"ver":"1.0.2","libVer":"1.0.0","author":"TechnoJo4","dep":["url>=1.0.0","CommonCSS>=1.0.0"]}
 
 local baseURL = "https://www.royalroad.com"
 local qs = Require("url").querystring
@@ -90,11 +90,13 @@ return {
 			local i = 0
 			novel:setChapters(AsList(map(doc:selectFirst("#chapters tbody"):children(), function(v)
 				local a = v:selectFirst("a")
+				local a_time = v:selectFirst("time")
 				i = i + 1
 				return NovelChapter {
 					order = i,
 					title = a:text(),
-					link = a:attr("href")
+					link = a:attr("href"),
+					release = (a_time and (a_time:attr("title") or a_time:attr("unixtime") or v:selectLast("a"):text())) or nil
 				}
 			end)))
 		end


### PR DESCRIPTION
The time element looks like this
`<time unixtime="1541246321" title="11/3/2018 11:58:41 AM +00:00" format="agoshort">3 years</time> ago`
I go in order of specificity, in case one day someone wants to convert all the times from all the extensions into the same format later, so first it tries `11/3/2018 11:58:41 AM +00:00` then `1541246321` then `3 years ago`.