### PR TITLE
Add Order to Madara, Update WuxiaDotBlog to HTML and Repair Listing

### DIFF
--- a/index.json
+++ b/index.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "Madara",
-      "ver": "2.3.0"
+      "ver": "2.3.1"
     }
   ],
   "scripts": [
@@ -256,7 +256,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/WuxiaDotBlog.png",
       "id": 1376,
       "lang": "en",
-      "ver": "1.0.5",
+      "ver": "2.0.0",
       "libVer": "1.0.0",
       "md5": "c4a2b8bfb6e6103ad0c8615fb6602bbe"
     },

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -1,4 +1,4 @@
--- {"ver":"2.3.0","author":"TechnoJo4","dep":["url"]}
+-- {"ver":"2.3.1","author":"TechnoJo4","dep":["url"]}
 
 local encode = Require("url").encode
 local text = function(v)
@@ -216,11 +216,14 @@ function defaults:parseNovel(url, loadChapters)
 		end
 
 		local chapterList = doc:select(self.chaptersListSelector)
+		local chapterOrder = chapterList:size()
 		local novelList = AsList(map(chapterList, function(v)
+			chapterOrder = chapterOrder - 1
 			return NovelChapter{
 				title = v:selectFirst("a"):text(),
 				link = self.shrinkURL(v:selectFirst("a"):attr("href")),
-				release = v:selectFirst("span.chapter-release-date"):text()
+				release = v:selectFirst("span.chapter-release-date"):text(),
+				order = chapterOrder
 			}
 		end))
 		Reverse(novelList)

--- a/src/en/WuxiaDotBlog.lua
+++ b/src/en/WuxiaDotBlog.lua
@@ -1,128 +1,113 @@
--- {"id":1376,"ver":"1.0.5","libVer":"1.0.0","author":"AriaMoradi"}
+-- {"id":1376,"ver":"2.0.0","libVer":"1.0.0","author":"AriaMoradi"}
 
 local baseURL = "https://www.wuxia.blog"
-local _links = {}
+-- An hash containing the already displayed links to avoid the same novel appearing on multiple pages.
+local _linksHash = {}
 
-local function shrinkURL(url)
-	return url:gsub(baseURL, "")
-end
+--- Removes the duplicate link entries from a list of novels.
+---@param novelList {Novel} A list of novels.
+---@param hash [boolean] If true, then the key (the link) has already been shown.
+---@return {Novel} The list of novels with removed duplicates.
+local function removeDuplicateNovels(novelList, hash)
+	local res = {}
+	if hash == nil then
+		hash = {}
+	end
 
-local function isLinkDuplicate(link)
-	for key, value in pairs(_links) do
-		if value == link then
-			return true
+	for _, novel in ipairs(novelList) do
+		if (not hash[novel:getLink()]) then
+			res[#res+1] = novel
+			hash[novel:getLink()] = true
 		end
 	end
-	_links[#_links+1] = link
-	return false
+	--[=====[
+	print("Source length: " .. #novelList)
+	print("Length: " .. #res)
+	for i, v in ipairs(res) do
+		print( i .. " " .. v:getTitle() .. " " .. v:getLink() .. " " .. v:getImageURL() )
+	end
+	--]=====]
+
+	return res, hash
 end
 
--- from ReadLightNovel
-local function identity(...)
-	return ...
+local function shrinkURL(url)
+	return url:gsub(".-wuxia%.blog", "")
 end
-local function pipeline(obj)
-    return function(f, ...)
-        if not f then
-            return obj
-        else
-            return pipeline(f(obj, ...))
-        end
-    end
+
+local function expandURL(url)
+	return baseURL .. url
 end
+
+local text = function(v) return v:text() end
 
 return {
 	id = 1376,
 	name = "wuxia.blog",
 	baseURL = baseURL,
 	imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/WuxiaDotBlog.png",
+	chapterType = ChapterType.HTML,
+
+	shrinkURL = shrinkURL,
+	expandURL = expandURL,
+
 	listings = {
 		Listing("Latest Updated", true, function(data)
-			return pipeline(GETDocument(baseURL .. "/?page=" .. data[PAGE]):select(".media"))
-				(map, function(it)
-					local novel = Novel()
-					novel:setLink(it:selectFirst(".media-body a"):attr("href"))
-					novel:setTitle(it:selectFirst(".media-heading"):text())
-					novel:setImageURL(baseURL .. "/" .. it:selectFirst("img"):attr("src"))
-					return novel
-				end, identity)
-				(filter, function (v)
-					return not isLinkDuplicate(v:getLink())
-				end)()
+			-- TODO Remove when start index of page is 1 instead of 0.
+			local pageOffset = 0
+			if data[PAGE] == 0 then
+				pageOffset = 1
+			end
+
+			-- Reset displayed link hash when starting with the first page.
+			if data[PAGE] + pageOffset == 1 then
+				_linksHash = {}
+			end
+
+			local document = GETDocument(expandURL( "/?page=" .. data[PAGE] + pageOffset)):select(".media")
+			local novels = map(document, function(it)
+				return Novel {
+					title = it:selectFirst(".media-heading"):text(),
+					link = it:selectFirst(".media-body a"):attr("href"),
+					imageURL = expandURL("/" .. it:selectFirst("img"):attr("src")),
+				}
+			end)
+
+			novels, _linksHash = removeDuplicateNovels(novels, _linksHash)
+			return novels
 		end),
 		Listing("Novel list", false, function(data)
-			return map(GETDocument(
-					baseURL .. "/listNovels")
+			return map(GETDocument(expandURL("/listNovels"))
 					:select("table tbody tr td:nth-child(2) a"), function(it)
-				local novel = Novel()
-				novel:setLink(it:attr("href"))
-				novel:setTitle(it:text())
-				return novel
+				return Novel {
+					link = it:attr("href"),
+					title = it:text()
+				}
 			end)
 		end)
 	},
-	shrinkURL = shrinkURL,
-	expandURL = function(url)
-		return baseURL .. url
-	end,
+
 	parseNovel = function(novelURL, loadChapters)
-		local novel = NovelInfo()
-		local document = GETDocument(baseURL .. novelURL)
+		local document = GETDocument(expandURL(novelURL))
+		local panel = document:selectFirst("div.panel.panel-default")
+		local panelBody = panel:selectFirst("div.panel-body .row")
+		local information = panelBody:selectFirst(".row")
 
-		novel:setTitle(document:selectFirst("h4.panel-title"):text())
-		novel:setImageURL(document:selectFirst(".imageCover img"):attr("src"))
-
-		novel:setAuthors(
-			map(
-				document:select(".panel-body .row .row .row > div:nth-child(2) > a"),
-				function (it)
-					return it:text()
-				end
-			)
-		)
-		novel:setGenres(
-			map(
-				document:select(".panel-body .row .row .label"),
-				function (it)
-					return it:text()
-				end
-			)
-		)
-		local k = map(
-			document:select(".panel-body .row .row .row > div:nth-child(2) > a"),
-			function (it)
-				return it:text()
-			end
-		)
-
-		novel:setAlternativeTitles(
-			map(
-				document:select(".panel-body .row .row .coll:nth-child(1) a"),
-				function (it)
-					return it:text()
-				end
-			)
-		)
-		novel:setTags(
-			map(
-				document:select(".panel .panel .label"),
-				function (it)
-					return it:text()
-				end
-			)
-		)
-
-		novel:setDescription(
-			string.match(
-				document:selectFirst('[itemprop="description"]'):text(),
-				"Description: (.*)"
-		))
+		local novel = NovelInfo {
+			title = panel:selectFirst("h4.panel-title"):text(),
+			setAlternativeTitles = map(information:select(".coll:nth-child(1) a"), text),
+			imageURL = panelBody:selectFirst(".imageCover img"):attr("src"),
+			description = table.concat(map(panelBody:selectFirst('[itemprop="description"]'):select("p"), text), "\n"),
+			genres = map(information:select(".label"), text),
+			tags = map(document:select(".panel .panel .label"), text),
+			authors = map(information:select(".row > div:nth-child(2) > a"), text)
+		}
 
 		if loadChapters then
 			local first100 = map(document:select("table tbody tr"), function(it, i)
 				local chap = NovelChapter()
 				chap:setTitle(it:selectFirst("a"):text())
-				chap:setLink(it:selectFirst("a"):attr("href"))
+				chap:setLink(shrinkURL(it:selectFirst("a"):attr("href")))
 				chap:setRelease(it:selectFirst("td:nth-child(2)"):text())
 				return chap
 			end)
@@ -131,15 +116,15 @@ return {
 			pcall(function ()
 				local moreEl = document:selectFirst("#more")
 				local nid = moreEl:attr("data-nid")
-				local document2 = GETDocument(baseURL .. '/temphtml/_tempChapterList_all_' .. tostring(nid) .. '.html')
+				local document2 = GETDocument(expandURL('/temphtml/_tempChapterList_all_' .. tostring(nid) .. '.html'))
 				local rest = map(document2:select("a"), function(it, i)
-					local chap = NovelChapter()
-					chap:setTitle(it:text())
-					chap:setLink(it:attr("href"))
-					chap:setRelease(it:nextSibling():text())
-					return chap
+					return NovelChapter {
+						title = it:text(),
+						link = shrinkURL(it:attr("href")),
+						release = it:nextSibling():text()
+					}
 				end)
-				for key,value in pairs(rest) do
+				for _,value in pairs(rest) do
 					first100[#first100+1] = value
 				end
 			end)
@@ -152,35 +137,32 @@ return {
 	end,
 
 	getPassage = function(chapterURL)
-		local document = GETDocument(chapterURL):select(".panel-body.article")
+		local htmlElement = GETDocument(expandURL(chapterURL)):selectFirst(".panel-body.article")
 
-		return pipeline(document:select("p"))
-			(map, function(v)
-				return v:text()
-			end)
-			(table.concat, "\n")
-			(string.gsub, "\n\n", "\n")
-			(string.gsub, "This chapter is updated by Wuxia.Blog\n", "")
-			(string.gsub, "Liked it?? Take a second to support Wuxia.Blog on Patreon!", "")()
+		-- Remove/modify unwanted HTML elements to get a clean webpage.
+		htmlElement:select("div"):remove()
+		htmlElement:select("button"):remove()
+
+		return pageOfElem(htmlElement, true)
 	end,
 
+	isSearchIncrementing = false,
 	search = function(data)
 		local result = {}
 
-		-- fails if query retuns nothing
+		-- fails if query returns nothing
 		pcall(function ()
-			local rows = GETDocument(baseURL .. "/?search=" .. string.gsub(data[QUERY]," ","+")):select("tr")
+			local rows = GETDocument(expandURL("/?search=" .. string.gsub(data[QUERY]," ","+"))):select("tr")
 			for i=1, rows:size()-1 do -- ignore the first
 				local row = rows:get(i)
-				local novel = Novel()
-				novel:setImageURL(row:selectFirst("td:nth-child(2) img"):attr("src"))
-				novel:setTitle(row:selectFirst("td:nth-child(3) a"):text())
-				novel:setLink(shrinkURL(row:selectFirst("td:nth-child(3) a"):attr("href")))
-
-				result[#result+1] = novel
+				result[#result+1] = Novel {
+					title = row:selectFirst("td:nth-child(3) a"):text(),
+					link = shrinkURL(row:selectFirst("td:nth-child(3) a"):attr("href")),
+					imageURL = row:selectFirst("td:nth-child(2) img"):attr("src")
+				}
 			end
 		end)
+
 		return result
 	end,
-	isSearchIncrementing = false,
 }


### PR DESCRIPTION
This is #208 without the libs and WWVolare changes. Therefore, closes #207 .
As imo the point of libraries is missed by auto installing them and therefore there seems to be the desire to not add unnecessary libraries and instead duplicate code between extensions, I removed the libraries and moved one needed function from a removed lib to WuxiaDotBlog. 
The WWVolare got scrapped.

Added the Order of NovelChapter to Madara and WuxiaBlog.
Fixing default listing ended up in partial rewrite of WuxiaDotBlog until the error of it starting with page 0 instead of 1 was noticed.
Changed WuxiaDotBlog to HTML chapters.
Shrank URL in WuxiaDotBlog where applicable.

Will change from draft when the a device test has been completed.