### PR TITLE
Update Status & Fix KobatoChan and NMTranslations

### DIFF
--- a/index.json
+++ b/index.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "NovelFull",
-      "ver": "2.0.3"
+      "ver": "2.0.4"
     },
     {
       "name": "url",
@@ -22,11 +22,11 @@
     },
     {
       "name": "WWVolare",
-      "ver": "1.2.0"
+      "ver": "1.2.1"
     },
     {
       "name": "Madara",
-      "ver": "2.3.1"
+      "ver": "2.3.2"
     }
   ],
   "scripts": [
@@ -266,7 +266,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/KobatoChan.png",
       "id": 74485,
       "lang": "en",
-      "ver": "1.1.0",
+      "ver": "1.1.1",
       "libVer": "1.0.0",
       "md5": ""
     },
@@ -276,7 +276,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/ScribbleHub.png",
       "id": 86802,
       "lang": "en",
-      "ver": "1.0.0",
+      "ver": "1.0.1",
       "libVer": "1.0.0",
       "md5": ""
     },
@@ -306,7 +306,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/NMTranslations.png",
       "id": 93082,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/lib/NovelFull.lua
+++ b/lib/NovelFull.lua
@@ -1,4 +1,4 @@
--- {"ver":"2.0.3","author":"TechnoJo4","dep":["url"]}
+-- {"ver":"2.0.4","author":"TechnoJo4","dep":["url"]}
 
 -- rename this if you ever figure out its real name
 
@@ -87,8 +87,10 @@ function defaults:parseNovel(url, loadChapters)
 	info:setAuthors(meta_links(0))
 	info:setAlternativeTitles(meta_links(1))
 	info:setGenres(meta_links(2))
-	info:setStatus(elem:get(meta_offset + 4):select("a"):text() == "Completed"
-			and NovelStatus.COMPLETED or NovelStatus.UNKNOWN)
+	info:setStatus( ({
+		Ongoing = NovelStatus.PUBLISHING,
+		Completed = NovelStatus.COMPLETED
+	})[elem:get(meta_offset + 4):select("a"):text()] )
 
 	info:setImageURL((self.appendURLToInfoImage and self.baseURL or "") .. doc:selectFirst("div.book img"):attr("src"))
 	info:setDescription(table.concat(map(doc:select("div.desc-text p"), text), "\n"))

--- a/lib/WWVolare.lua
+++ b/lib/WWVolare.lua
@@ -1,4 +1,4 @@
--- {"ver":"1.2.0","author":"TechnoJo4","dep":["dkjson","CommonCSS"]}
+-- {"ver":"1.2.1","author":"TechnoJo4","dep":["dkjson","CommonCSS"]}
 
 local css = Require("CommonCSS").table
 
@@ -35,7 +35,9 @@ return function(id, name, base, contentSel, image)
 				tags = v.tags,
 				genres = v.genres,
 				language = v.language,
-				status = v.status == 1 and NovelStatus.PUBLISHING or NovelStatus.UNKNOWN
+				status = v.status == 1 and NovelStatus.PUBLISHING
+						or v.status == 2 and NovelStatus.COMPLETED
+						or NovelStatus.UNKNOWN
 			}
 		end
 	end

--- a/src/en/KobatoChan.lua
+++ b/src/en/KobatoChan.lua
@@ -1,4 +1,4 @@
--- {"id":74485,"ver":"1.1.0","libVer":"1.0.0","author":"TechnoJo4"}
+-- {"id":74485,"ver":"1.1.1","libVer":"1.0.0","author":"TechnoJo4"}
 
 local baseURL = "https://kobatochan.com"
 
@@ -54,7 +54,7 @@ return {
 			return map(flatten(mapNotNil(doc:selectFirst("nav#access ul"):children(), function(v)
 				local text = v:selectFirst("a"):text()
 				return (text:find("Novels", 0, true) or text == "Original Works") and
-						map(v:selectFirst("ul.sub-menu"):select("a"), function(v) return v end)
+						map(v:selectFirst("ul.sub-menu"):select("> li > a"), function(v) return v end)
 			end)), function(v)
 				return Novel {
 					title = v:text(),

--- a/src/en/NMTranslations.lua
+++ b/src/en/NMTranslations.lua
@@ -1,4 +1,4 @@
--- {"id":93082,"ver":"2.0.0","libVer":"1.0.0","author":"Doomsdayrs"}
+-- {"id":93082,"ver":"2.0.1","libVer":"1.0.0","author":"Doomsdayrs"}
 local baseURL = "https://www.nanomashin.online"
 
 local function text(v)
@@ -26,10 +26,9 @@ return {
 	listings = {
 		Listing("Projects", false, function()
 			local doc = GETDocument(baseURL)
-
-			return map(doc:select("div.p-4 a"), function(v)
+			return map(doc:select("div.shadow-md div.flex a"), function(v)
 				return Novel {
-					title = v:selectFirst("h2"):text(),
+					title = v:text(),
 					link = v:attr("href"),
 					imageURL = expandURL("/_next/image?url=%2Fstatic%2Fimages%2F" .. v:attr("href") .. "-cover.png&w=384&q=75"),
 				}
@@ -42,7 +41,7 @@ return {
 
 		local info = NovelInfo {
 			title = document:selectFirst("h1.text-3xl"):text(),
-			imageURL = expandURL(document:selectFirst("img.object-contain"):attr("src")),
+			imageURL = expandURL("/_next/image?url=%2Fstatic%2Fimages%2F" .. url .. "-cover.png&w=384&q=75"),
 			description = document:selectFirst("div.pt-6.pb-8"):selectFirst("div.pt-6.pb-8"):text(),
 		}
 

--- a/src/en/ScribbleHub.lua
+++ b/src/en/ScribbleHub.lua
@@ -1,4 +1,4 @@
--- {"id":86802,"ver":"1.0.0","libVer":"1.0.0","author":"TechnoJo4","dep":["url>=1.0.0","CommonCSS>=1.0.0"]}
+-- {"id":86802,"ver":"1.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["url>=1.0.0","CommonCSS>=1.0.0"]}
 
 local baseURL = "https://www.scribblehub.com"
 local qs = Require("url").querystring
@@ -84,6 +84,8 @@ return {
 			s = NovelStatus.PUBLISHING
 		elseif s:match("Complete") then
 			s = NovelStatus.COMPLETED
+		elseif s:match("Hiatus") then
+			s = NovelStatus.PAUSED
 		else
 			s = NovelStatus.UNKNOWN
 		end
@@ -118,7 +120,9 @@ return {
 	end,
 
 	getPassage = function(url)
-		local chap = GETDoc(expandURL(url)):getElementById("chp_raw")
+		local chap = GETDoc(expandURL(url)):getElementById("main read chapter")
+		local title = chap:selectFirst(".chapter-title"):text()
+		chap = chap:getElementById("chp_raw")
 
 		-- remove empty <p> tags
 		local toRemove = {}
@@ -133,6 +137,9 @@ return {
 		for _,v in pairs(toRemove) do
 			v:remove()
 		end
+
+		-- Chapter title inserted before chapter text
+		chap:child(0):before("<h1>" .. title .. "</h1>");
 
 		return pageOfElem(chap, false, css)
 	end,


### PR DESCRIPTION
Update the novel status of Madara, NovelFull, WWVolare, and ScribbleHub.
Add title to ScribbleHub chapter.
Fix NMTranslations listing being empty.
KobatoChan filter out glossaries from novels.

Solves a few problems noted in #222 .