### PR TITLE
Fix TravisTranslation chapters not loading.

### DIFF
--- a/index.json
+++ b/index.json
@@ -226,7 +226,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/TravisTranslations.png",
       "id": 4302,
       "lang": "en",
-      "ver": "1.0.10",
+      "ver": "1.0.11",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/TravisTranslations.lua
+++ b/src/en/TravisTranslations.lua
@@ -1,4 +1,4 @@
--- {"id":4302,"ver":"1.0.10","libVer":"1.0.0","author":"MechTechnology"}
+-- {"id":4302,"ver":"1.0.11","libVer":"1.0.0","author":"MechTechnology"}
 
 local baseURL = "https://travistranslations.com"
 
@@ -92,8 +92,8 @@ end
 
 local function getPassage(chapterURL)
 	local chap = GETDocument(expandURL(chapterURL)):selectFirst("main#primary")
-	local title = content:selectFirst("h2"):text()
-	chap = content:selectFirst(".reader-content")
+	local title = chap:selectFirst("h2"):text()
+	chap = chap:selectFirst(".reader-content")
 	chap:child(0):before("<h1>" .. title .. "</h1>")
 	-- Remove empty <p> tags
 	local toRemove = {}


### PR DESCRIPTION
- Allows chapter passages to work.
- I was using my own version of the extension, but I tried the extension from the main repo and found that chapters were not loading. The reason was a variable name typo that was not renamed correctly during code review.
- This small commit fix that issue and allows chapter passages to load normal.