### PR TITLE
ScribbleHub: Improve empty paragraph removal

### DIFF
--- a/index.json
+++ b/index.json
@@ -316,7 +316,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/ScribbleHub.png",
       "id": 86802,
       "lang": "en",
-      "ver": "1.0.1",
+      "ver": "1.0.2",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/ScribbleHub.lua
+++ b/src/en/ScribbleHub.lua
@@ -1,4 +1,4 @@
--- {"id":86802,"ver":"1.0.1","libVer":"1.0.0","author":"TechnoJo4","dep":["url>=1.0.0","CommonCSS>=1.0.0"]}
+-- {"id":86802,"ver":"1.0.2","libVer":"1.0.0","author":"TechnoJo4","dep":["url>=1.0.0","CommonCSS>=1.0.0"]}
 
 local baseURL = "https://www.scribblehub.com"
 local qs = Require("url").querystring
@@ -124,10 +124,12 @@ return {
 		local title = chap:selectFirst(".chapter-title"):text()
 		chap = chap:getElementById("chp_raw")
 
-		-- remove empty <p> tags
+		-- Remove <p></p>.
 		local toRemove = {}
 		chap:traverse(NodeVisitor(function(v)
-			if v:tagName() == "p" and v:text() == "" then
+			if v:tagName() == "p" and v:childNodeSize() == 0 then -- and v:text() == "" then
+				-- childNodeSize() == 0 iff <tag></tag>, therefore not triggered by <p> </p>.
+				-- Avoids removal of things like <p><img src="some link"></p> though.
 				toRemove[#toRemove+1] = v
 			end
 			if v:hasAttr("border") then

--- a/src/en/ScribbleHub.lua
+++ b/src/en/ScribbleHub.lua
@@ -127,9 +127,7 @@ return {
 		-- Remove <p></p>.
 		local toRemove = {}
 		chap:traverse(NodeVisitor(function(v)
-			if v:tagName() == "p" and v:childNodeSize() == 0 then -- and v:text() == "" then
-				-- childNodeSize() == 0 iff <tag></tag>, therefore not triggered by <p> </p>.
-				-- Avoids removal of things like <p><img src="some link"></p> though.
+			if v:tagName() == "p" and v:childrenSize() == 0 and v:text() == "" then
 				toRemove[#toRemove+1] = v
 			end
 			if v:hasAttr("border") then


### PR DESCRIPTION
Improves the empty paragraph (< p>< /p>) removal.
Encountered problem is that < p>< img src="some link">< /p> gets removed due to not having any text. Replaced text() == "" with childNodeSize() == 0, which is true iff < tag>< /tag>. 
Disadvantage though is that it is not triggered by < p> < /p> due to any text counting as a child.