### PR TITLE
Removes workaround to fix missing listing page

### DIFF
--- a/index.json
+++ b/index.json
@@ -226,7 +226,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/RainOfSnow.png",
       "id": 4300,
       "lang": "en",
-      "ver": "1.1.0",
+      "ver": "1.1.1",
       "libVer": "1.0.0",
       "md5": ""
     },
@@ -246,7 +246,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/TravisTranslations.png",
       "id": 4302,
       "lang": "en",
-      "ver": "1.0.11",
+      "ver": "1.0.12",
       "libVer": "1.0.0",
       "md5": ""
     },
@@ -256,7 +256,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/Mylovenovel.png",
       "id": 4303,
       "lang": "en",
-      "ver": "1.0.1",
+      "ver": "1.0.2",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/Mylovenovel.lua
+++ b/src/en/Mylovenovel.lua
@@ -1,4 +1,4 @@
--- {"id":4303,"ver":"1.0.1","libVer":"1.0.0","author":"MechTechnology"}
+-- {"id":4303,"ver":"1.0.2","libVer":"1.0.0","author":"MechTechnology"}
 
 local baseURL = "https://www.mylovenovel.com"
 
@@ -107,16 +107,14 @@ end
 
 local function getSearch(data)
 	local query = data[QUERY]
-	-- Remove the +1 work around when the indexing gets changed.
-	local page = data[PAGE] + 1
+	local page = data[PAGE]
 	local url = "/index.php?s=so&module=book&keyword=" .. query .. "&page=" .. page
 	return parseListing(expandURL(url))
 end
 
 local function getListing(data)
 	-- Filters only work with the listing, their search does not support them.
-	-- Remove the +1 work around when the indexing gets changed.
-	local page = data[PAGE] + 1
+	local page = data[PAGE] 
 	local status = STATUS_TERMS[data[STATUS_FILTER]+1]
 	local orderBy = ORDER_BY_TERMS[data[ORDER_BY_FILTER]+1]
 	local genre = ""

--- a/src/en/RainOfSnow.lua
+++ b/src/en/RainOfSnow.lua
@@ -1,4 +1,4 @@
--- {"id":4300,"ver":"1.1.0","libVer":"1.0.0","author":"MechTechnology"}
+-- {"id":4300,"ver":"1.1.1","libVer":"1.0.0","author":"MechTechnology"}
 
 local baseURL = "https://rainofsnow.com"
 
@@ -114,8 +114,7 @@ local function parseListing(listingURL)
 end
 
 local function getListing(data)
-	-- Remove the +1 work around when the indexing gets changed.
-	local page = data[PAGE] + 1
+	local page = data[PAGE]
 	local orderBy = data[ORDER_BY_FILTER]
 	local genre = data[GENRE_FILTER]
 	

--- a/src/en/TravisTranslations.lua
+++ b/src/en/TravisTranslations.lua
@@ -1,4 +1,4 @@
--- {"id":4302,"ver":"1.0.11","libVer":"1.0.0","author":"MechTechnology"}
+-- {"id":4302,"ver":"1.0.12","libVer":"1.0.0","author":"MechTechnology"}
 
 local baseURL = "https://travistranslations.com"
 
@@ -162,8 +162,7 @@ end
 
 local function getSearch(data)
 	local query = data[QUERY]
-	-- Remove the +1 work around when the indexing gets changed.
-	local page = data[PAGE] + 1
+	local page = data[PAGE]
 	local status = data[STATUS_FILTER]
 	local orderBy = data[ORDER_BY_FILTER]
 


### PR DESCRIPTION
- Now that listing view is fixed, this removes the workaround that was made so novels don't get duplicated.
- It also fixes the fact that workaround in the new update now hides the first page of the search/listing result in those extensions.
- I don't know if updating is easy thou...