### PR TITLE
WuxiaDotBlog: Remove Page 0 Workaround

### DIFF
--- a/index.json
+++ b/index.json
@@ -306,7 +306,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/WuxiaDotBlog.png",
       "id": 1376,
       "lang": "en",
-      "ver": "2.0.0",
+      "ver": "2.0.1",
       "libVer": "1.0.0",
       "md5": "c4a2b8bfb6e6103ad0c8615fb6602bbe"
     },

--- a/src/en/WuxiaDotBlog.lua
+++ b/src/en/WuxiaDotBlog.lua
@@ -1,4 +1,4 @@
--- {"id":1376,"ver":"2.0.0","libVer":"1.0.0","author":"AriaMoradi"}
+-- {"id":1376,"ver":"2.0.1","libVer":"1.0.0","author":"AriaMoradi"}
 
 local baseURL = "https://www.wuxia.blog"
 -- An hash containing the already displayed links to avoid the same novel appearing on multiple pages.
@@ -53,18 +53,12 @@ return {
 
 	listings = {
 		Listing("Latest Updated", true, function(data)
-			-- TODO Remove when start index of page is 1 instead of 0.
-			local pageOffset = 0
-			if data[PAGE] == 0 then
-				pageOffset = 1
-			end
-
 			-- Reset displayed link hash when starting with the first page.
-			if data[PAGE] + pageOffset == 1 then
+			if data[PAGE] == 1 then
 				_linksHash = {}
 			end
 
-			local document = GETDocument(expandURL( "/?page=" .. data[PAGE] + pageOffset)):select(".media")
+			local document = GETDocument(expandURL( "/?page=" .. data[PAGE])):select(".media")
 			local novels = map(document, function(it)
 				return Novel {
 					title = it:selectFirst(".media-heading"):text(),


### PR DESCRIPTION
I did not test it on device as I have not yet updated and am still on 1731. If it actually starts on page 1 now though this should work fine like it does for the current extension tester.