### PR TITLE
Excludes premium chapters WoopRead

### DIFF
--- a/index.json
+++ b/index.json
@@ -166,7 +166,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/WoopRead.png",
       "id": 4217,
       "lang": "en",
-      "ver": "2.1.0",
+      "ver": "2.2.0",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/Woopread.lua
+++ b/src/en/Woopread.lua
@@ -1,11 +1,11 @@
--- {"id":4217,"ver":"2.1.0","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.2.0"]}
+-- {"id":4217,"ver":"2.2.0","libVer":"1.0.0","author":"TechnoJo4","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://woopread.com", {
     id = 4217,
     name = "WoopRead",
     imageURL = "https://github.com/shosetsuorg/extensions/raw/dev/icons/WoopRead.png",
-
     -- defaults values
+    chaptersListSelector= "li.wp-manga-chapter.free-chap",
     novelListingURLPath = "novellist",
     shrinkURLNovel = "series",
     searchHasOper = true,


### PR DESCRIPTION
- Fixes an issue where some novels don't load their chapter list... example Resetting Lady.
- This issue seem to be triggered by premium chapter as it has occured before in mystic merries extension.
- This removes premium chapters from chapter list for woopread.
- This should not affect users, since premium chapters are not viewable/reable within the app anyways.