### PR TITLE
Fix Novel Hard can't properly load

### DIFF
--- a/index.json
+++ b/index.json
@@ -156,7 +156,7 @@
       "imageURL": "https://novelhard.com/wp-content/uploads/2019/08/novelhard.com_-1.png",
       "id": 81,
       "lang": "en",
-      "ver": "2.1.1",
+      "ver": "2.1.2",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/NovelTrench.lua
+++ b/src/en/NovelTrench.lua
@@ -1,4 +1,4 @@
--- {"id":81,"ver":"2.1.1","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.2.0"]}
+-- {"id":81,"ver":"2.1.2","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.2.0"]}
 
 return Require("Madara")("https://novelhard.com",{
 	id = 81,
@@ -8,8 +8,12 @@ return Require("Madara")("https://novelhard.com",{
 	-- defaults values
 	latestNovelSel = "div.col-12.col-md-4.badge-pos-1",
 	novelListingURLPath = "novel",
-	shrinkURLNovel = "novel",
+	shrinkURLNovel = "light-novel",
 	searchHasOper = true,
+
+	shrinkURL = function(url)
+		return url:gsub("https?://.-/light%-novel/", "")
+	end,
 
 	genres = {
 		"Action",


### PR DESCRIPTION
Use separate shrink URL function for NovelHard
This is to circumvent a regex character `-` in the keyword

Additional Note:
I think this is better be fixed in Madara itself, maybe in the future there's another website that use regex special characters.

In this case, because the new prefix is `light-novel` which contains `-` character. On shrinkUrl function this is treated as regex character (to find multiple instance of character before it, which is `t`). So it just try to replace `lightnovel` without `-`.
On the other hand, adding special character `%` to treat `-` as normal character will cause other function to use wrong value i.e. `light%-novel`

I think there's multiple option to fix this:
1. change shrink/expand method to just remove base url, also needs to remove the usage of `shrinkURLNovel` in `parseNovel` function. I'm not sure if this is safe, and I don't know what usecase needed to not directly use baseURL on expand/shrink
2. add extra variable for shrinkUrl function only, on default this variable has same value as `shrinkURLNovel` but can be overridden if needed

both methods work fine on testing random novel that use madara using extenstion tester 