### PR TITLE
Change shrink/expand URL for NovelTrench

### DIFF
--- a/index.json
+++ b/index.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "Madara",
-      "ver": "2.4.0"
+      "ver": "2.4.2"
     }
   ],
   "scripts": [
@@ -156,7 +156,7 @@
       "imageURL": "https://novelhard.com/wp-content/uploads/2019/08/novelhard.com_-1.png",
       "id": 81,
       "lang": "en",
-      "ver": "2.1.2",
+      "ver": "2.1.3",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/lib/Madara.lua
+++ b/lib/Madara.lua
@@ -1,4 +1,4 @@
--- {"ver":"2.4.1","author":"TechnoJo4","dep":["url"]}
+-- {"ver":"2.4.2","author":"TechnoJo4","dep":["url"]}
 
 local encode = Require("url").encode
 local text = function(v)
@@ -229,7 +229,7 @@ function defaults:parseNovel(url, loadChapters)
 			else
 				-- Used by BoxNovel, Foxaholic, NovelTrench, LightNovelHeaven, VipNovel and WoopRead.
 				doc = RequestDocument(
-						POST(self.baseURL .. "/" .. self.shrinkURLNovel .. "/" .. url .. self.ajaxSeriesUrl,
+						POST(self.expandURL(url) .. self.ajaxSeriesUrl,
 								nil, nil)
 				)
 			end

--- a/src/en/NovelTrench.lua
+++ b/src/en/NovelTrench.lua
@@ -1,4 +1,4 @@
--- {"id":81,"ver":"2.1.2","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.2.0"]}
+-- {"id":81,"ver":"2.1.3","libVer":"1.0.0","author":"Doomsdayrs","dep":["Madara>=2.4.2"]}
 
 return Require("Madara")("https://novelhard.com",{
 	id = 81,
@@ -8,11 +8,14 @@ return Require("Madara")("https://novelhard.com",{
 	-- defaults values
 	latestNovelSel = "div.col-12.col-md-4.badge-pos-1",
 	novelListingURLPath = "novel",
-	shrinkURLNovel = "light-novel",
+	shrinkURLNovel = "",
 	searchHasOper = true,
 
+	expandURL = function(url)
+		return "https://novelhard.com/" .. url
+	end,
 	shrinkURL = function(url)
-		return url:gsub("https?://.-/light%-novel/", "")
+		return url:gsub("https://novelhard.com/", "")
 	end,
 
 	genres = {


### PR DESCRIPTION
Update Madara code to use expandURL instead of manually concatenate the url

NovelHard changes their url structure again. So instead of just updating the keyword, might as well change the extension to ignore the keyword after base URL. This needs an update on Madara code because one of expansion of URL is not using expandURL function. Changing that allowing the extension to use custom expand/shrink URL