### PR TITLE
Fixes to MoonlightNovels and Readhive extentions

### DIFF
--- a/index.json
+++ b/index.json
@@ -276,7 +276,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/Readhive.png",
       "id": 4304,
       "lang": "en",
-      "ver": "1.0.1",
+      "ver": "1.0.2",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/index.json
+++ b/index.json
@@ -286,7 +286,7 @@
       "imageURL": "https://github.com/shosetsuorg/extensions/raw/dev/icons/MoonlightNovels.png",
       "id": 4305,
       "lang": "en",
-      "ver": "1.0.0",
+      "ver": "1.1.0",
       "libVer": "1.0.0",
       "md5": ""
     },

--- a/src/en/Readhive.lua
+++ b/src/en/Readhive.lua
@@ -1,4 +1,4 @@
--- {"id":4304,"ver":"1.0.1","libVer":"1.0.0","author":"MechTechnology"}
+-- {"id":4304,"ver":"1.0.2","libVer":"1.0.0","author":"MechTechnology"}
 
 local baseURL = "https://readhive.org"
 
@@ -88,7 +88,7 @@ end
 local function getPassage(chapterURL)
 	local doc = GETDocument(expandURL(chapterURL))
 	local title = doc:selectFirst("h1"):text()
-	local chap = doc:selectFirst(".justify-center.flex-grow.mx-auto.prose")
+	local chap = doc:selectFirst(".justify-center.flex-grow.mx-auto.prose .mb-4")
 	chap = clearNewLines(chap)
 	chap:child(0):before("<h1>" .. title .. "</h1>")
 	return pageOfElem(chap, true)


### PR DESCRIPTION
**MoonlightNovels**
- Fixes listing not working (Due to website redesign).
- Adjusts the url for hot novel listing and all novel listing.
- Adds completed listing.
- Disables search, since they intentionally broken the search in their site.
- Now loads paginated chapters lists in novel parsing (Site now has a max of 50 chapters per page in each novel TOC).

**Readhive**
- Removes the font resize buttons/sliders from the end of the chapter passage.


